### PR TITLE
Fixed incorrect date cut-off time on forwarding events. Take timezone…

### DIFF
--- a/app/src/main/java/app/michaelwuensch/bitbanana/forwarding/listItems/DateItem.java
+++ b/app/src/main/java/app/michaelwuensch/bitbanana/forwarding/listItems/DateItem.java
@@ -1,5 +1,7 @@
 package app.michaelwuensch.bitbanana.forwarding.listItems;
 
+import java.util.TimeZone;
+
 public class DateItem extends ForwardingListItem {
 
     public long mDate; // in milliseconds
@@ -12,7 +14,8 @@ public class DateItem extends ForwardingListItem {
         // To get the date line to show up at the correct position in the sorted list, we have to set its timestamp correctly.
         // We set it to 1 nanosecond before the day ends.
         // 86400000000000 = Nanoseconds of one day (60 * 60 * 24 * 1000 * 1000 * 1000)
-        mTimestampNS = (timestamp - (timestamp % 86400000000000L) + (86400000000000L - 1));
+        TimeZone timeZone = TimeZone.getDefault();
+        mTimestampNS = (timestamp - (timeZone.getOffset(mDate) * 1000000L) - (timestamp % 86400000000000L) + (86400000000000L - 1));
     }
 
     @Override

--- a/app/src/main/java/app/michaelwuensch/bitbanana/forwarding/listItems/DateLineViewHolder.java
+++ b/app/src/main/java/app/michaelwuensch/bitbanana/forwarding/listItems/DateLineViewHolder.java
@@ -5,11 +5,17 @@ import android.widget.TextView;
 
 import java.text.DateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 import app.michaelwuensch.bitbanana.R;
 
 public class DateLineViewHolder extends ForwardingItemViewHolder {
     private TextView mTvDate;
+    private TimeZone timeZone;
+
+    {
+        timeZone = TimeZone.getDefault();
+    }
 
     public DateLineViewHolder(View v) {
         super(v);
@@ -19,7 +25,7 @@ public class DateLineViewHolder extends ForwardingItemViewHolder {
 
     public void bindDateItem(DateItem dateItem) {
         DateFormat df = DateFormat.getDateInstance(DateFormat.LONG, mContext.getResources().getConfiguration().locale);
-        String formattedDate = df.format(new Date(dateItem.mDate));
+        String formattedDate = df.format(new Date(dateItem.mDate - timeZone.getOffset(dateItem.mDate)));
 
         // Check if this date was today or yesterday
         String formattedDateYesterday = df.format(getYesterday());
@@ -37,10 +43,10 @@ public class DateLineViewHolder extends ForwardingItemViewHolder {
     }
 
     private Date getYesterday() {
-        return new Date(System.currentTimeMillis() - 24 * 60 * 60 * 1000);
+        return new Date(System.currentTimeMillis() - timeZone.getOffset(System.currentTimeMillis()) - 24 * 60 * 60 * 1000);
     }
 
     private Date getToday() {
-        return new Date();
+        return new Date(System.currentTimeMillis() - timeZone.getOffset(System.currentTimeMillis()));
     }
 }


### PR DESCRIPTION
… into account.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes the visual bug on the DateLineView in the forwarding event page so that it cuts off at 12am according to the devices timezone, instead of cutting off at 12am UTC regardless.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I wanted to make this change because as I am living in a GMT+8 timezone, the cut-off for 'Today', 'Yesterday', and previous dates happens at 8.00am instead of 12.00am in the current version.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested this by building the debug apk and running it on my device Samsung Galaxy S21.

I tested using my default GMT+8 timezone and also switching to a GMT-7 timezone to see the difference. 

While doing this, I came across another issue where if your timezone is in the negatives, the first DateLineView will show as 'Yesterday' instead of 'Today', and it will display another 'Yesterday' for the next cut-off making the page show 'Yesterday' two times. This has also been fixed in this PR.
## Screenshots (if appropriate):

Unable to take screenshots due to security policy.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.