### PR TITLE
Added balance details on home screen

### DIFF
--- a/app/src/main/java/app/michaelwuensch/bitbanana/customView/AmountView.java
+++ b/app/src/main/java/app/michaelwuensch/bitbanana/customView/AmountView.java
@@ -34,6 +34,7 @@ public class AmountView extends LinearLayout implements SharedPreferences.OnShar
     private boolean mCanBlur;
     private boolean mIsBlurred = false;
     private String mAmountText;
+    private boolean mSubscribeToPrefChange;
 
 
     public AmountView(Context context) {
@@ -58,9 +59,6 @@ public class AmountView extends LinearLayout implements SharedPreferences.OnShar
         mTvLabel = view.findViewById(R.id.amountLabel);
         mTvAmount = view.findViewById(R.id.amountTextView);
 
-        if (!isInEditMode())
-            PrefsUtil.getPrefs().registerOnSharedPreferenceChangeListener(this);
-
         // Apply attributes from XML
         if (attrs != null) {
             // Obtain the custom attribute value from the XML attributes
@@ -70,6 +68,7 @@ public class AmountView extends LinearLayout implements SharedPreferences.OnShar
             mIsWithoutUnit = a.getBoolean(R.styleable.AmountView_isWithoutUnit, false);
             boolean attrShowLabel = a.getBoolean(R.styleable.AmountView_showLabel, false);
             mCanBlur = a.getBoolean(R.styleable.AmountView_canBlur, true);
+            mSubscribeToPrefChange = a.getBoolean(R.styleable.AmountView_subscribeToPrefChange, true);
             int attrTextSize = a.getDimensionPixelSize(R.styleable.AmountView_textSize, 0);
             ColorStateList attrTextColor = a.getColorStateList(R.styleable.AmountView_textColor);
 
@@ -83,6 +82,9 @@ public class AmountView extends LinearLayout implements SharedPreferences.OnShar
             // Don't forget to recycle the TypedArray
             a.recycle();
         }
+
+        if (!isInEditMode() && mSubscribeToPrefChange)
+            PrefsUtil.getPrefs().registerOnSharedPreferenceChangeListener(this);
 
         if (mSwitchesValueOnClick || isBlurActivated()) {
             mTvAmount.setOnClickListener(new OnClickListener() {
@@ -227,6 +229,7 @@ public class AmountView extends LinearLayout implements SharedPreferences.OnShar
 
     public void setCanBlur(boolean canBlur) {
         mCanBlur = canBlur;
+        removeBlur(false);
     }
 
     public void setSwitchValueOnClick(boolean switchValueOnClick) {

--- a/app/src/main/java/app/michaelwuensch/bitbanana/customView/MainBalanceView.java
+++ b/app/src/main/java/app/michaelwuensch/bitbanana/customView/MainBalanceView.java
@@ -1,0 +1,319 @@
+package app.michaelwuensch.bitbanana.customView;
+
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.animation.Animation;
+import android.view.animation.AnimationUtils;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.constraintlayout.motion.widget.MotionLayout;
+import androidx.constraintlayout.widget.ConstraintLayout;
+
+import app.michaelwuensch.bitbanana.R;
+import app.michaelwuensch.bitbanana.connection.manageNodeConfigs.NodeConfigsManager;
+import app.michaelwuensch.bitbanana.util.BBLog;
+import app.michaelwuensch.bitbanana.util.Balances;
+import app.michaelwuensch.bitbanana.util.MonetaryUtil;
+import app.michaelwuensch.bitbanana.util.PrefsUtil;
+import app.michaelwuensch.bitbanana.util.Wallet;
+
+public class MainBalanceView extends MotionLayout {
+    private static final String LOG_TAG = MainBalanceView.class.getSimpleName();
+
+    private MotionLayout mMotionLayout;
+    private TextView mTvPrimaryBalance;
+    private TextView mTvPrimaryBalanceUnit;
+    private TextView mTvSecondaryBalance;
+    private TextView mTvSecondaryBalanceUnit;
+    private TextView mTvMode;
+    private ConstraintLayout mClBalanceLayout;
+    private ImageView mIvLogo;
+    private ImageView mIvSwitchButton;
+    private ImageView mIvHandleIcon;
+    private FrameLayout mFLHandleForClick;
+    private Animation mBalanceFadeOutAnimation;
+    private Animation mLogoFadeInAnimation;
+    private boolean mAnimationAborted;
+    private AmountView mAvOnChain;
+    private AmountView mAvOnChainPending;
+    private AmountView mAvLighting;
+    private AmountView mAvLightningPending;
+
+    private boolean mIsExpanded;
+    private boolean mIsTransitioning;
+
+    public MainBalanceView(Context context) {
+        super(context);
+        init();
+    }
+
+    public MainBalanceView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public MainBalanceView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    private void init() {
+        View view = inflate(getContext(), R.layout.main_balance_view, this);
+
+        mMotionLayout = view.findViewById(R.id.balanceViewMotionLayout);
+        mClBalanceLayout = view.findViewById(R.id.BalanceLayout);
+        mIvLogo = view.findViewById(R.id.logo);
+        mIvHandleIcon = view.findViewById(R.id.handleIcon);
+        mFLHandleForClick = view.findViewById(R.id.handleForClick);
+        mIvSwitchButton = view.findViewById(R.id.switchButtonImage);
+        mTvPrimaryBalance = view.findViewById(R.id.BalancePrimary);
+        mTvPrimaryBalanceUnit = view.findViewById(R.id.BalancePrimaryUnit);
+        mTvSecondaryBalance = view.findViewById(R.id.BalanceSecondary);
+        mTvSecondaryBalanceUnit = view.findViewById(R.id.BalanceSecondaryUnit);
+        mTvMode = view.findViewById(R.id.mode);
+        mBalanceFadeOutAnimation = AnimationUtils.loadAnimation(getContext(), R.anim.balance_fade_out);
+        mLogoFadeInAnimation = AnimationUtils.loadAnimation(getContext(), R.anim.logo_fade_in);
+        mAvOnChain = view.findViewById(R.id.onChainConfirmed);
+        mAvOnChainPending = view.findViewById(R.id.onChainPending);
+        mAvLighting = view.findViewById(R.id.lightningConfirmed);
+        mAvLightningPending = view.findViewById(R.id.lightningPending);
+
+
+        /*
+        Making it possible to touch drag and click at the same time turned out to be tricky.
+        Adding an OnClickListener to the handle stopped drag touch to work.
+        Here is how it is done now:
+        1. We register an onTouchListener for the whole MotionLayout. The area is obviously much bigger than the handle
+           Therefore we added a isInside() function that can check if the motion Event happened inside a specific view.
+           We cannot just use the handle to check this, as the handle is animated in ScaleY it will yield incorrect results.
+        2. Therefore we add another Handle, which is transparent and at the exact same location and does not get animated in ScaleY.
+        3. If the motionAction is UP and it was inside the bounds of that second handle, we trigger the motion scene to animate.
+         */
+        mMotionLayout.setOnTouchListener(new OnTouchListener() {
+            @Override
+            public boolean onTouch(View view, MotionEvent motionEvent) {
+                if (isInside(mFLHandleForClick, motionEvent)) {
+                    if (motionEvent.getAction() == MotionEvent.ACTION_UP) {
+                        // Handle touch up
+                        if (mIsExpanded)
+                            mMotionLayout.transitionToStart();
+                        else
+                            mMotionLayout.transitionToEnd();
+                    }
+                }
+                return false;
+            }
+        });
+
+        mMotionLayout.setTransitionListener(new MotionLayout.TransitionListener() {
+            @Override
+            public void onTransitionStarted(MotionLayout motionLayout, int i, int i1) {
+
+            }
+
+            @Override
+            public void onTransitionChange(MotionLayout motionLayout, int i, int i1, float v) {
+                mIsTransitioning = true;
+            }
+
+            @Override
+            public void onTransitionCompleted(MotionLayout motionLayout, int i) {
+                // update isExpanded state
+                mIsExpanded = i == R.id.end;
+                if (mIsExpanded) {
+                    mBalanceFadeOutAnimation.reset();
+                    abortAnimation();
+                    setVisibilityOfBalanceFadeoutViews(View.VISIBLE);
+                    mIvLogo.setVisibility(View.INVISIBLE);
+                } else {
+                    if (hideMainBalance()) {
+                        restartFadeOut();
+                    }
+                }
+                mIsTransitioning = false;
+            }
+
+
+            @Override
+            public void onTransitionTrigger(MotionLayout motionLayout, int i, boolean b, float v) {
+
+            }
+        });
+
+
+        mBalanceFadeOutAnimation.setAnimationListener(new Animation.AnimationListener() {
+            @Override
+            public void onAnimationStart(Animation arg0) {
+                setVisibilityOfBalanceFadeoutViews(View.VISIBLE);
+                mIvLogo.setVisibility(View.INVISIBLE);
+            }
+
+            @Override
+            public void onAnimationRepeat(Animation arg0) {
+            }
+
+            @Override
+            public void onAnimationEnd(Animation arg0) {
+                if (!mAnimationAborted) {
+                    setVisibilityOfBalanceFadeoutViews(View.INVISIBLE);
+                    mIvLogo.setVisibility(View.VISIBLE);
+                    mIvLogo.startAnimation(mLogoFadeInAnimation);
+                }
+            }
+        });
+
+
+        // Action when clicked on the logo
+        mIvLogo.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                restartFadeOut();
+            }
+        });
+
+
+        // Swap action when clicked on balance or cancel the fade out in case balance is hidden
+        mClBalanceLayout.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (hideMainBalance() && !mIsExpanded) {
+                    restartFadeOut();
+                } else {
+                    MonetaryUtil.getInstance().switchCurrencies();
+                }
+            }
+        });
+
+        // Swap action when clicked swap icon next to balance
+        mIvSwitchButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                MonetaryUtil.getInstance().switchCurrencies();
+
+                // also cancel fade out if hideTotalBalance option is active
+                if (hideMainBalance() && !mIsExpanded) {
+                    restartFadeOut();
+                }
+            }
+        });
+    }
+
+    public void updateBalances() {
+
+        // Finish transition before updating the balances. If done while transitioning, layout gets unrecoverably broken.
+        if (mIsTransitioning) {
+            if (mIsExpanded)
+                mMotionLayout.jumpToState(R.id.start);
+            else
+                mMotionLayout.jumpToState(R.id.end);
+        }
+
+
+        Handler threadHandler = new Handler(Looper.getMainLooper());
+        threadHandler.post(new Runnable() {
+            @Override
+            public void run() {
+
+                // Adapt unit text size depending on its length
+                if (MonetaryUtil.getInstance().getPrimaryDisplayUnit().length() > 2) {
+                    mTvPrimaryBalanceUnit.setTextSize(20);
+                } else {
+                    mTvPrimaryBalanceUnit.setTextSize(32);
+                }
+
+                Balances balances;
+                if (NodeConfigsManager.getInstance().hasAnyConfigs()) {
+                    balances = Wallet.getInstance().getBalances();
+                } else {
+                    balances = Wallet.getInstance().getDemoBalances();
+                }
+
+                mTvPrimaryBalance.setText(MonetaryUtil.getInstance().getPrimaryDisplayAmountStringFromSats(balances.total()));
+                mTvPrimaryBalanceUnit.setText(MonetaryUtil.getInstance().getPrimaryDisplayUnit());
+                mTvSecondaryBalance.setText(MonetaryUtil.getInstance().getSecondaryDisplayAmountStringFromSats(balances.total()));
+                mTvSecondaryBalanceUnit.setText(MonetaryUtil.getInstance().getSecondaryDisplayUnit());
+
+                // Balance details
+                mAvOnChain.setAmountSat(balances.onChainConfirmed());
+                mAvOnChainPending.setAmountSat(balances.onChainUnconfirmed());
+                mAvLighting.setAmountSat(balances.channelBalance());
+                mAvLightningPending.setAmountSat(balances.channelBalancePending());
+
+                BBLog.v(LOG_TAG, "Total balance display updated");
+            }
+        });
+    }
+
+    public void updateNetworkInfo() {
+        if (NodeConfigsManager.getInstance().hasAnyConfigs()) {
+            switch (Wallet.getInstance().getNetwork()) {
+                case MAINNET:
+                    mTvMode.setVisibility(View.GONE);
+                    break;
+                case TESTNET:
+                    mTvMode.setText("TESTNET");
+                    mTvMode.setVisibility(View.VISIBLE);
+                    break;
+                case REGTEST:
+                    mTvMode.setText("REGTEST");
+                    mTvMode.setVisibility(View.VISIBLE);
+            }
+        } else {
+            // Wallet is not setup
+            mTvMode.setVisibility(View.GONE);
+        }
+    }
+
+    public void hideBalance() {
+        setVisibilityOfBalanceFadeoutViews(View.INVISIBLE);
+        mIvLogo.setVisibility(View.VISIBLE);
+    }
+
+    public void showBalance() {
+        setVisibilityOfBalanceFadeoutViews(View.VISIBLE);
+        mIvLogo.setVisibility(View.INVISIBLE);
+    }
+
+    private boolean isInside(View v, MotionEvent e) {
+        int[] location = new int[2];
+        v.getLocationOnScreen(location);
+
+        float rawX = e.getRawX();
+        float rawY = e.getRawY();
+
+        return (rawX >= location[0] && rawX <= (location[0] + v.getWidth())
+                && rawY >= location[1] && rawY <= (location[1] + v.getHeight()));
+    }
+
+    private boolean hideMainBalance() {
+        return !PrefsUtil.getPrefs().getString(PrefsUtil.BALANCE_HIDE_TYPE, "off").equals("off");
+
+    }
+
+    private void restartFadeOut() {
+        mBalanceFadeOutAnimation.reset();
+        mClBalanceLayout.startAnimation(mBalanceFadeOutAnimation);
+        mIvSwitchButton.startAnimation(mBalanceFadeOutAnimation);
+        mIvHandleIcon.startAnimation(mBalanceFadeOutAnimation);
+        mAnimationAborted = false;
+    }
+
+    private void setVisibilityOfBalanceFadeoutViews(int visibility) {
+        mClBalanceLayout.setVisibility(visibility);
+        mIvSwitchButton.setVisibility(visibility);
+        mIvHandleIcon.setVisibility(visibility);
+    }
+
+    private void abortAnimation() {
+        mAnimationAborted = true;
+        mClBalanceLayout.clearAnimation();
+        mIvSwitchButton.clearAnimation();
+        mIvHandleIcon.clearAnimation();
+    }
+}

--- a/app/src/main/res/layout/fragment_wallet.xml
+++ b/app/src/main/res/layout/fragment_wallet.xml
@@ -92,137 +92,19 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <TextView
-            android:id="@+id/mode"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:paddingStart="16dp"
-            android:paddingTop="8dp"
-            android:paddingEnd="16dp"
-            android:paddingBottom="10dp"
-            android:textAlignment="textEnd"
-            android:textColor="@color/gray"
-            android:textSize="20sp"
-            app:layout_constraintBottom_toTopOf="@+id/BalanceLayout"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            tools:text="TESTNET" />
-
-        <ImageView
-            android:id="@+id/logo"
-            android:layout_width="75dp"
-            android:layout_height="75dp"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="8dp"
-            android:layout_marginBottom="8dp"
-            android:src="@drawable/bitbanana_logo"
-            android:visibility="gone"
-            app:layout_constraintBottom_toTopOf="@+id/sendButton"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.4" />
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/BalanceLayout"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="8dp"
-            android:layout_marginBottom="8dp"
-            app:layout_constraintBottom_toTopOf="@+id/sendButton"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0.4">
-
-            <LinearLayout
-                android:id="@+id/BalancePrimaryLayout"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginStart="8dp"
-                android:layout_marginEnd="8dp"
-                android:orientation="horizontal"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent">
-
-                <TextView
-                    android:id="@+id/BalancePrimary"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:textAlignment="center"
-                    android:textColor="@color/white"
-                    android:textSize="38sp"
-                    android:textStyle="bold"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    tools:text="Primary" />
-
-                <app.michaelwuensch.bitbanana.customView.NonClippingTextView
-                    android:id="@+id/BalancePrimaryUnit"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="8dp"
-                    android:textAlignment="center"
-                    android:textColor="@color/white"
-                    android:textSize="20sp"
-                    android:textStyle="italic"
-                    tools:text="BTC" />
-
-            </LinearLayout>
-
-            <LinearLayout
-                android:id="@+id/BalanceSecondaryLayout"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginStart="8dp"
-                android:layout_marginEnd="8dp"
-                android:orientation="horizontal"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/BalancePrimaryLayout">
-
-                <TextView
-                    android:id="@+id/BalanceSecondary"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:textAlignment="center"
-                    android:textColor="@color/gray"
-                    android:textSize="15sp"
-                    app:layout_constraintTop_toBottomOf="@id/BalancePrimary"
-                    tools:text="Secondary" />
-
-                <app.michaelwuensch.bitbanana.customView.NonClippingTextView
-                    android:id="@+id/BalanceSecondaryUnit"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="6dp"
-                    android:textAlignment="center"
-                    android:textColor="@color/gray"
-                    android:textSize="15sp"
-                    android:textStyle="italic"
-                    tools:text="sat" />
-            </LinearLayout>
-
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
 
         <LinearLayout
             android:id="@+id/scanButton"
             android:layout_width="80dp"
             android:layout_height="80dp"
-            android:layout_marginBottom="50dp"
             android:background="@drawable/button_scan_ripple"
             android:gravity="center"
             android:orientation="vertical"
             app:layout_constraintBottom_toTopOf="@id/sendButton"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent">
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/mainBalanceView"
+            app:layout_constraintVertical_bias="0.75">
 
             <ImageView
                 android:layout_width="36dp"
@@ -268,28 +150,29 @@
             app:layout_constraintHorizontal_bias="0.74"
             app:layout_constraintStart_toEndOf="@+id/sendButton" />
 
-        <ImageView
-            android:id="@+id/switchButtonImage"
-            android:layout_width="28dp"
-            android:layout_height="50dp"
-            android:layout_marginTop="4dp"
-            android:paddingStart="0dp"
-            android:paddingEnd="10dp"
-            android:src="@drawable/ic_swap_vert_black_24dp"
-            app:layout_constraintBottom_toBottomOf="@+id/BalanceLayout"
-            app:layout_constraintStart_toEndOf="@+id/BalanceLayout"
-            app:layout_constraintTop_toTopOf="@+id/BalanceLayout"
-            app:layout_constraintVertical_bias="0.6"
-            app:tint="@color/banana_yellow" />
+        <app.michaelwuensch.bitbanana.customView.MainBalanceView
+            android:id="@+id/mainBalanceView"
+            android:layout_width="match_parent"
+            android:layout_height="400dp"
+            app:layout_constraintBottom_toTopOf="@id/sendButton"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0.2" />
+
+        <androidx.constraintlayout.widget.Guideline
+            android:id="@+id/guidelineTop"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            app:layout_constraintGuide_percent="0.55" />
 
         <Button
             android:id="@+id/setupWallet"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
             android:layout_marginEnd="8dp"
-            android:layout_marginBottom="8dp"
             android:background="@drawable/rounded_rectangle_orange_gradient"
             android:paddingStart="15dp"
             android:paddingEnd="15dp"
@@ -298,7 +181,7 @@
             app:layout_constraintBottom_toTopOf="@+id/scanButton"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/BalanceLayout" />
+            app:layout_constraintTop_toBottomOf="@+id/guidelineTop" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/main_balance_view.xml
+++ b/app/src/main/res/layout/main_balance_view.xml
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.motion.widget.MotionLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/balanceViewMotionLayout"
+    android:layout_width="match_parent"
+    android:layout_height="400dp"
+    app:layoutDescription="@xml/balance_view_motion_scene">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/unexpandedContent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <TextView
+            android:id="@+id/mode"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:paddingStart="16dp"
+            android:paddingTop="8dp"
+            android:paddingEnd="16dp"
+            android:paddingBottom="10dp"
+            android:textAlignment="textEnd"
+            android:textColor="@color/gray"
+            android:textSize="20sp"
+            app:layout_constraintBottom_toTopOf="@+id/BalanceLayout"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:text="TESTNET" />
+
+        <ImageView
+            android:id="@+id/logo"
+            android:layout_width="75dp"
+            android:layout_height="75dp"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="8dp"
+            android:src="@drawable/bitbanana_logo"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/BalanceLayout"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <LinearLayout
+                android:id="@+id/BalancePrimaryLayout"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:orientation="horizontal"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent">
+
+                <TextView
+                    android:id="@+id/BalancePrimary"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAlignment="center"
+                    android:textColor="@color/white"
+                    android:textSize="38sp"
+                    android:textStyle="bold"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="Primary" />
+
+                <app.michaelwuensch.bitbanana.customView.NonClippingTextView
+                    android:id="@+id/BalancePrimaryUnit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:textAlignment="center"
+                    android:textColor="@color/white"
+                    android:textSize="20sp"
+                    android:textStyle="italic"
+                    tools:text="BTC" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/BalanceSecondaryLayout"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
+                android:orientation="horizontal"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/BalancePrimaryLayout">
+
+                <TextView
+                    android:id="@+id/BalanceSecondary"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAlignment="center"
+                    android:textColor="@color/gray"
+                    android:textSize="15sp"
+                    app:layout_constraintTop_toBottomOf="@id/BalancePrimary"
+                    tools:text="Secondary" />
+
+                <app.michaelwuensch.bitbanana.customView.NonClippingTextView
+                    android:id="@+id/BalanceSecondaryUnit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="6dp"
+                    android:textAlignment="center"
+                    android:textColor="@color/gray"
+                    android:textSize="15sp"
+                    android:textStyle="italic"
+                    tools:text="sat" />
+            </LinearLayout>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <ImageView
+            android:id="@+id/switchButtonImage"
+            android:layout_width="28dp"
+            android:layout_height="50dp"
+            android:layout_marginTop="4dp"
+            android:paddingStart="0dp"
+            android:paddingEnd="10dp"
+            android:src="@drawable/ic_swap_vert_black_24dp"
+            app:layout_constraintBottom_toBottomOf="@+id/BalanceLayout"
+            app:layout_constraintStart_toEndOf="@+id/BalanceLayout"
+            app:layout_constraintTop_toTopOf="@+id/BalanceLayout"
+            app:layout_constraintVertical_bias="0.6"
+            app:tint="@color/banana_yellow" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <FrameLayout
+        android:id="@+id/expandedContent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.7">
+
+        <LinearLayout
+            android:id="@+id/balanceDetails"
+            android:layout_width="290dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:orientation="vertical">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/balance_details_on_chain_confirmed"
+                    android:textSize="16sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <app.michaelwuensch.bitbanana.customView.AmountView
+                    android:id="@+id/onChainConfirmed"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    app:canBlur="false"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:subscribeToPrefChange="false"
+                    app:textSize="18sp" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/balance_details_on_chain_unconfirmed"
+                    android:textSize="16sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <app.michaelwuensch.bitbanana.customView.AmountView
+                    android:id="@+id/onChainPending"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    app:canBlur="false"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:subscribeToPrefChange="false"
+                    app:textSize="18sp" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/balance_details_lightning"
+                    android:textSize="16sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <app.michaelwuensch.bitbanana.customView.AmountView
+                    android:id="@+id/lightningConfirmed"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    app:canBlur="false"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:subscribeToPrefChange="false"
+                    app:textSize="18sp" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/balance_details_lightning_pending"
+                    android:textSize="16sp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <app.michaelwuensch.bitbanana.customView.AmountView
+                    android:id="@+id/lightningPending"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    app:canBlur="false"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:subscribeToPrefChange="false"
+                    app:textSize="18sp" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </LinearLayout>
+    </FrameLayout>
+
+    <FrameLayout
+        android:id="@+id/handleForClick"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.6" />
+
+    <FrameLayout
+        android:id="@+id/handle"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:scaleY="1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.6">
+
+        <ImageView
+            android:id="@+id/handleIcon"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:src="@drawable/ic_arrow_down_24dp"
+            app:tint="@color/banana_yellow" />
+    </FrameLayout>
+
+
+</androidx.constraintlayout.motion.widget.MotionLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -9,6 +9,7 @@
         <attr name="setLabelText" format="string" />
         <attr name="textSize" format="dimension" />
         <attr name="textColor" format="color" />
+        <attr name="subscribeToPrefChange" format="boolean" />
     </declare-styleable>
 
     <declare-styleable name="BBInputFieldView">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -697,4 +697,9 @@
     <string name="peer_total_capacity">Total Capacity</string>
     <string name="peer_total_capacity_explanation">Total node capacity, derived from the sum of channel capacities.</string>
     <string name="peer_features">Features</string>
+
+    <string name="balance_details_on_chain_confirmed">On-Chain confirmed:</string>
+    <string name="balance_details_on_chain_unconfirmed">On-Chain pending:</string>
+    <string name="balance_details_lightning">Open channels:</string>
+    <string name="balance_details_lightning_pending">Pending channels:</string>
 </resources>

--- a/app/src/main/res/xml/balance_view_motion_scene.xml
+++ b/app/src/main/res/xml/balance_view_motion_scene.xml
@@ -1,0 +1,124 @@
+<MotionScene xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:motion="http://schemas.android.com/apk/res-auto">
+    <Transition
+        motion:constraintSetEnd="@+id/end"
+        motion:constraintSetStart="@+id/start"
+        motion:duration="300"
+        motion:motionInterpolator="easeInOut">
+
+        <OnSwipe
+            motion:dragDirection="dragUp"
+            motion:touchAnchorId="@id/handle"
+            motion:touchRegionId="@id/handle" />
+
+    </Transition>
+
+    <ConstraintSet android:id="@+id/start">
+        <Constraint android:id="@id/unexpandedContent">
+            <Layout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                motion:layout_constraintBottom_toBottomOf="parent"
+                motion:layout_constraintEnd_toEndOf="parent"
+                motion:layout_constraintStart_toStartOf="parent"
+                motion:layout_constraintTop_toTopOf="parent"
+                motion:layout_constraintVertical_bias="0.5" />
+            <CustomAttribute
+                motion:attributeName="alpha"
+                motion:customFloatValue="1" />
+        </Constraint>
+        <Constraint android:id="@id/expandedContent">
+            <Layout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                motion:layout_constraintBottom_toBottomOf="parent"
+                motion:layout_constraintEnd_toEndOf="parent"
+                motion:layout_constraintStart_toStartOf="parent"
+                motion:layout_constraintTop_toTopOf="parent"
+                motion:layout_constraintVertical_bias="0.7" />
+            <CustomAttribute
+                motion:attributeName="alpha"
+                motion:customFloatValue="0" />
+        </Constraint>
+        <Constraint android:id="@id/handle">
+            <Layout
+                android:layout_width="36dp"
+                android:layout_height="36dp"
+                motion:layout_constraintBottom_toBottomOf="parent"
+                motion:layout_constraintEnd_toEndOf="parent"
+                motion:layout_constraintStart_toStartOf="parent"
+                motion:layout_constraintTop_toTopOf="parent"
+                motion:layout_constraintVertical_bias="0.65" />
+            <CustomAttribute
+                motion:attributeName="scaleY"
+                motion:customFloatValue="1" />
+        </Constraint>
+        <Constraint android:id="@id/handleForClick">
+            <Layout
+                android:layout_width="36dp"
+                android:layout_height="36dp"
+                motion:layout_constraintBottom_toBottomOf="parent"
+                motion:layout_constraintEnd_toEndOf="parent"
+                motion:layout_constraintStart_toStartOf="parent"
+                motion:layout_constraintTop_toTopOf="parent"
+                motion:layout_constraintVertical_bias="0.65" />
+            <CustomAttribute
+                motion:attributeName="alpha"
+                motion:customFloatValue="0" />
+        </Constraint>
+    </ConstraintSet>
+    <ConstraintSet android:id="@+id/end">
+        <Constraint android:id="@id/unexpandedContent">
+            <Layout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                motion:layout_constraintBottom_toBottomOf="parent"
+                motion:layout_constraintEnd_toEndOf="parent"
+                motion:layout_constraintStart_toStartOf="parent"
+                motion:layout_constraintTop_toTopOf="parent"
+                motion:layout_constraintVertical_bias="0.4" />
+            <CustomAttribute
+                motion:attributeName="alpha"
+                motion:customFloatValue="1" />
+        </Constraint>
+        <Constraint android:id="@id/expandedContent">
+            <Layout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                motion:layout_constraintBottom_toBottomOf="parent"
+                motion:layout_constraintEnd_toEndOf="parent"
+                motion:layout_constraintStart_toStartOf="parent"
+                motion:layout_constraintTop_toTopOf="parent"
+                motion:layout_constraintVertical_bias="0.77" />
+            <CustomAttribute
+                motion:attributeName="alpha"
+                motion:customFloatValue="1" />
+        </Constraint>
+        <Constraint android:id="@id/handle">
+            <Layout
+                android:layout_width="36dp"
+                android:layout_height="36dp"
+                motion:layout_constraintBottom_toBottomOf="parent"
+                motion:layout_constraintEnd_toEndOf="parent"
+                motion:layout_constraintStart_toStartOf="parent"
+                motion:layout_constraintTop_toTopOf="parent"
+                motion:layout_constraintVertical_bias="0.9" />
+            <CustomAttribute
+                motion:attributeName="scaleY"
+                motion:customFloatValue="-1" />
+        </Constraint>
+        <Constraint android:id="@id/handleForClick">
+            <Layout
+                android:layout_width="36dp"
+                android:layout_height="36dp"
+                motion:layout_constraintBottom_toBottomOf="parent"
+                motion:layout_constraintEnd_toEndOf="parent"
+                motion:layout_constraintStart_toStartOf="parent"
+                motion:layout_constraintTop_toTopOf="parent"
+                motion:layout_constraintVertical_bias="0.9" />
+            <CustomAttribute
+                motion:attributeName="alpha"
+                motion:customFloatValue="0" />
+        </Constraint>
+    </ConstraintSet>
+</MotionScene>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds more information to the current balance by expanding the balance display.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is one of the most requested things ever. So far BitBanana tried to unify the balance to simplify the UI and UX.
But this leads to problems where users don't understand why certain operations do not work.
It was possible to get more information about the current balance with a long Tap on the balance, but it was not obvious that this function existed and only very few knew about it.
Now it should be obvious and it is easy to access the information about your balance distribution between on-chain, lightning and currently pending funds.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
My S22, Emulators

## Screenshots (if appropriate):
![img](https://github.com/michaelWuensch/BitBanana/assets/15313630/f472011f-d7ca-40c6-92a6-23107ca51168)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.