### PR TITLE
Handle cases where mLnPaymentRequest is null on fee calculation

### DIFF
--- a/app/src/main/java/app/michaelwuensch/bitbanana/fragments/SendBSDFragment.java
+++ b/app/src/main/java/app/michaelwuensch/bitbanana/fragments/SendBSDFragment.java
@@ -277,7 +277,7 @@ public class SendBSDFragment extends BaseBSDFragment {
                 if (mAmountValid) {
                     mSendAmountSat = MonetaryUtil.getInstance().convertPrimaryTextInputToSatoshi(arg0.toString());
 
-                    if (!mOnChain && mLnPaymentRequest.getNumSatoshis() == 0) {
+                    if (!mOnChain && mLnPaymentRequest != null && mLnPaymentRequest.getNumSatoshis() == 0) {
                         mSendButtonEnabled_feeCalculate = false;
                         mFeeCaclulationDebounceHandler.attempt(new Runnable() {
                             @Override


### PR DESCRIPTION
Encountered a bug where the app would crash when any amount of sats was entered when sending funds using keysend, just before fee calculation happened. Found out a check handling some special case (not sure what) was missing a null check.

## Description
In some cases (all of my cases on the last version :D) the app would crash when attempting to send any amount of funds to another node using keysend. Just before fee calculation, there is a check for some special case (did not investigate), which was attempting to call `getNumSatoshis` on `mLnPaymentRequest`, which was null at the time. Added a null check to handle this case, and "fall back" to regular `calculateFee`.

## Motivation and Context
_Why is this change required? What problem does it solve?_
I use BitBanana for sending funds. I would like to be able to do that :D
_If it fixes an open issue, please link to the issue here._
None open that I know of.

## How Has This Been Tested?
Performed a single keysend transaction of 5 satoshis.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [?] My code follows the code style of this project.
  - not sure, link to code standards in docs was not functioning
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
  - no, `parseCoinbaseResponse` and `parseBlockchainInfoResponse` both failed, none related to my change, not knowledgeable about this project enough to investigate further