### PR TITLE
LndConnection, CoreLightningConnection: specifiy an allowlist for TLS versions and ciphers to use for connections

### DIFF
--- a/app/src/main/java/app/michaelwuensch/bitbanana/backends/coreLightning/connection/CoreLightningConnection.java
+++ b/app/src/main/java/app/michaelwuensch/bitbanana/backends/coreLightning/connection/CoreLightningConnection.java
@@ -88,6 +88,7 @@ public class CoreLightningConnection {
                         .forAddress(host, port)
                         .hostnameVerifier(hostnameVerifier) // null = default hostnameVerifier
                         .sslSocketFactory(inspectingFactory) // null = default SSLSocketFactory
+                        .tlsConnectionSpec(RefConstants.TLS_VERSIONS, RefConstants.CIPHER_SUITES)
                         .overrideAuthority("cln") // the grpc plugin for core lightning does not know the domain, therefore it uses 'cln' by default. See https://docs.corelightning.org/docs/grpc.
                         .maxInboundMessageSize(RefConstants.MAX_GRPC_MESSAGE_SIZE)
                         .build();

--- a/app/src/main/java/app/michaelwuensch/bitbanana/backends/lnd/connection/LndConnection.java
+++ b/app/src/main/java/app/michaelwuensch/bitbanana/backends/lnd/connection/LndConnection.java
@@ -177,6 +177,7 @@ public class LndConnection {
                         .forAddress(host, port)
                         .hostnameVerifier(hostnameVerifier) // null = default hostnameVerifier
                         .sslSocketFactory(inspectingFactory) // null = default SSLSocketFactory
+                        .tlsConnectionSpec(RefConstants.TLS_VERSIONS, RefConstants.CIPHER_SUITES)
                         .maxInboundMessageSize(RefConstants.MAX_GRPC_MESSAGE_SIZE)
                         .build();
             }

--- a/app/src/main/java/app/michaelwuensch/bitbanana/util/RefConstants.java
+++ b/app/src/main/java/app/michaelwuensch/bitbanana/util/RefConstants.java
@@ -2,6 +2,9 @@ package app.michaelwuensch.bitbanana.util;
 
 import java.util.concurrent.TimeUnit;
 
+import okhttp3.CipherSuite;
+import okhttp3.TlsVersion;
+
 public class RefConstants {
 
     /* This value has to be increased if any changes are made, that break the current implementation.
@@ -113,4 +116,26 @@ public class RefConstants {
     // Other
     public static final String SETUP_MODE = "setupMode";
     public static final String BITBANANA_UTXO_LEASE_ID = "bb21212121212121212121212121212121212121212121212121212121212121";
+
+    // TLS versions to use for SSL connections
+    public static final String[] TLS_VERSIONS = {
+            TlsVersion.TLS_1_2.javaName(),
+            TlsVersion.TLS_1_3.javaName()
+    };
+    // Ciphers to use for SSL connections
+    public static final String[] CIPHER_SUITES = {
+            // TLS v1.3
+            CipherSuite.TLS_AES_128_GCM_SHA256.javaName(),
+            CipherSuite.TLS_AES_256_GCM_SHA384.javaName(),
+            CipherSuite.TLS_CHACHA20_POLY1305_SHA256.javaName(),
+            CipherSuite.TLS_AES_128_CCM_SHA256.javaName(),
+            CipherSuite.TLS_AES_128_CCM_8_SHA256.javaName(),
+            // TLS v1.2
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256.javaName(),
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256.javaName(),
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384.javaName(),
+            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384.javaName(),
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256.javaName(),
+            CipherSuite.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256.javaName()
+    };
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

TLS v1.3 is added, enabling connections to TLS v1.3-only servers. The ciphers for TLS v1.2 are unchanged from the defaults of gRPC. TLS v1.1 and below stays disabled.

_Tor connections are unchanged. Let me know if I should adapt them as well._

## Motivation and Context

Fix #155. Connect with TLS v1.3 if available.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested against LND with TLS v1.2 and TLS v1.3.

TLS v1.2 is unlikely to regress because its cipher list didn't change.

I could not test Core Lightning.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [Contribution document](../docs/CONTRIBUTING.md).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.